### PR TITLE
update type-string handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@
 *build*
 *.h5
 *.pytest_cache*
-
+*install*
+python/test_**
+docs/html/**

--- a/include/fire/ConditionsProvider.h
+++ b/include/fire/ConditionsProvider.h
@@ -204,14 +204,14 @@ class ConditionsProvider {
  * // in source file
  * //   the names of the variables don't matter as long as they are different
  * namespace {
- * auto v0 = ::fire::ConditionsProvider::Factory.get().declare<One>("One");
- * auto v1 = ::fire::ConditionsProvider::Factory.get().declare<Two>("Two");
+ * auto v0 = ::fire::ConditionsProvider::Factory.get().declare<One>();
+ * auto v1 = ::fire::ConditionsProvider::Factory.get().declare<Two>();
  * }
  * ```
  */
-#define DECLARE_CONDITIONS_PROVIDER(CLASS)                                  \
-  namespace {                                                               \
-  auto v = fire::ConditionsProvider::Factory::get().declare<CLASS>(#CLASS); \
+#define DECLARE_CONDITIONS_PROVIDER(CLASS)                            \
+  namespace {                                                         \
+  auto v = fire::ConditionsProvider::Factory::get().declare<CLASS>(); \
   }
 
 #endif

--- a/include/fire/Processor.h
+++ b/include/fire/Processor.h
@@ -418,14 +418,14 @@ class Processor {
  * ```cpp
  * // in source file
  * namespace {
- * auto v0 = ::fire::Processor::Factory.get().declare<One>("One");
- * auto v1 = ::fire::Processor::Factory.get().declare<Two>("Two");
+ * auto v0 = ::fire::Processor::Factory.get().declare<One>();
+ * auto v1 = ::fire::Processor::Factory.get().declare<Two>();
  * }
  * ```
  */
-#define DECLARE_PROCESSOR(CLASS)                                   \
-  namespace {                                                      \
-  auto v = fire::Processor::Factory::get().declare<CLASS>(#CLASS); \
+#define DECLARE_PROCESSOR(CLASS)                             \
+  namespace {                                                \
+  auto v = fire::Processor::Factory::get().declare<CLASS>(); \
   }
 
 #endif

--- a/test/highlevel.cxx
+++ b/test/highlevel.cxx
@@ -66,8 +66,8 @@ class TestGet : public Processor {
  * in the same compilation unit.
  */
 namespace {
-  auto v0 = ::fire::Processor::Factory::get().declare<fire::test::TestAdd>("fire::test::TestAdd");
-  auto v1 = ::fire::Processor::Factory::get().declare<fire::test::TestGet>("fire::test::TestGet");
+  auto v0 = ::fire::Processor::Factory::get().declare<fire::test::TestAdd>();
+  auto v1 = ::fire::Processor::Factory::get().declare<fire::test::TestGet>();
 }
 
 /**

--- a/test/processor.cxx
+++ b/test/processor.cxx
@@ -53,9 +53,9 @@ class TestThrow : public fire::Processor {
  * compilation unit.
  */
 namespace {
-  auto v0 = ::fire::Processor::Factory::get().declare<test::TestProcessor>("test::TestProcessor");
-  auto v1 = ::fire::Processor::Factory::get().declare<test::TestProcessor2>("test::TestProcessor2");
-  auto v2 = ::fire::Processor::Factory::get().declare<test::TestThrow>("test::TestThrow");
+  auto v0 = ::fire::Processor::Factory::get().declare<test::TestProcessor>();
+  auto v1 = ::fire::Processor::Factory::get().declare<test::TestProcessor2>();
+  auto v2 = ::fire::Processor::Factory::get().declare<test::TestThrow>();
 }
 
 /**


### PR DESCRIPTION
This resolves #21 by implementing the following two patches

- use demangling in factory because it doesn't make sense to be 
  loading libraries compiled by a different compiler
  (not a perfect argument, but it has been put into documentation)
- update exception handling in Event to use serialized type as a hint in
  the exception message rather than requirement that it should be identical
  (more helpful than string comparison)
