### PR TITLE
Update Bool Serialization to Conform with h5py

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ if (fire_USE_ROOT)
   # include ROOT reader in io submodule
   add_library(io SHARED 
     src/fire/io/Writer.cxx
+    src/fire/io/Atomic.cxx
     src/fire/io/ParameterStorage.cxx
     src/fire/io/h5/Reader.cxx
     src/fire/io/root/Reader.cxx)
@@ -110,10 +111,12 @@ else()
   message(WARNING "Reading ROOT files will not be supported.")
   add_library(io SHARED 
     src/fire/io/Writer.cxx
+    src/fire/io/Atomic.cxx
     src/fire/io/ParameterStorage.cxx
     src/fire/io/h5/Reader.cxx)
   target_link_libraries(io PUBLIC version config HighFive)
 endif()
+
 add_library(framework SHARED
   src/fire/StorageControl.cxx
   src/fire/Event.cxx

--- a/include/fire/io/Atomic.h
+++ b/include/fire/io/Atomic.h
@@ -1,6 +1,10 @@
 #ifndef FIRE_IO_ATOMIC_H
 #define FIRE_IO_ATOMIC_H
 
+#include <type_traits>
+
+#include <highfive/H5DataType.hpp>
+
 namespace fire::io {
 
 /**
@@ -37,5 +41,8 @@ enum class Bool : bool {
 HighFive::EnumType<Bool> create_enum_bool();
 
 }  // namespace fire::h5
+
+template<>
+HighFive::DataType HighFive::create_datatype<fire::io::Bool>();
 
 #endif

--- a/include/fire/io/Atomic.h
+++ b/include/fire/io/Atomic.h
@@ -20,6 +20,22 @@ using is_atomic =
 template <typename AtomicType>
 inline constexpr bool is_atomic_v = is_atomic<AtomicType>::value;
 
+/**
+ * Boolean enum aligned with h5py
+ *
+ * We serialize bools in the same method as h5py so that
+ * Python-based analyses are easier.
+ */
+enum class Bool : bool {
+  TRUE  = true,
+  FALSE = false
+};
+
+/**
+ * HighFive method for creating the enum data type
+ */
+HighFive::EnumType<Bool> create_enum_bool();
+
 }  // namespace fire::h5
 
 #endif

--- a/include/fire/io/Atomic.h
+++ b/include/fire/io/Atomic.h
@@ -1,3 +1,5 @@
+/** @file Atomic.h */
+
 #ifndef FIRE_IO_ATOMIC_H
 #define FIRE_IO_ATOMIC_H
 
@@ -40,8 +42,25 @@ enum class Bool : bool {
  */
 HighFive::EnumType<Bool> create_enum_bool();
 
-}  // namespace fire::h5
+}  // namespace fire::io
 
+/**
+ * full specialization of HighFive template function
+ *
+ * This is necessary for compile-time registration of a new type
+ * and is usually hidden within the HIGHFIVE_REGISTER_TYPE macro.
+ *
+ * The reason we have to _not_ use the macro here is two fold.
+ * 1. We need the declaration of this registration to be done in this header 
+ *    so that it is accessible by both the fire::io target and the downstream
+ *    fire::framework target.
+ * 2. We need to define the registration only once to avoid a duplicate
+ *    definition compiler error during the linking step.
+ *
+ * These two goals can be met by splitting the declaration and the 
+ * definition of this full specialization into the header and source
+ * files of Atomic.
+ */
 template<>
 HighFive::DataType HighFive::create_datatype<fire::io::Bool>();
 

--- a/include/fire/io/Writer.h
+++ b/include/fire/io/Writer.h
@@ -91,6 +91,8 @@ class Writer {
       //    for flushing purposes
       // - the length of the buffer is the same size as the chunks in
       //    HDF5, this is done on purpose
+      // - if the type is a bool, we define the HighFive type to be
+      //    our custom enum which mimics the type used by h5py
       HighFive::DataType t;
       if constexpr (std::is_same_v<AtomicType,bool>) {
         t = create_enum_bool();
@@ -223,6 +225,9 @@ class Writer {
      * a compile-time choice that handles the std::vector<bool>
      * specialization
      * [bug in HighFive](https://github.com/BlueBrain/HighFive/issues/490).
+     * *and* translates bools into our custom enum fire::io::Bool
+     * which mimics the serialization behavior of the bool type
+     * understandable by h5py.
      *
      * Finally, we update the file index, clear the buffer,
      * and re-reserve the maximum length of the buffer to prepare

--- a/include/fire/io/h5/Reader.h
+++ b/include/fire/io/h5/Reader.h
@@ -288,12 +288,12 @@ class Reader : public ::fire::io::Reader {
       // load the next chunk into memory
       if constexpr (std::is_same_v<AtomicType,bool>) {
         // get around std::vector<bool> specialization
-        auto buff = std::make_unique<bool[]>(request_len);
+        std::vector<Bool> buff;
+        buff.resize(request_len);
         this->set_.select({i_file_}, {request_len})
-          .read(buff.get(), HighFive::AtomicType<bool>());
-        buffer_.reserve(request_len);
-        for (std::size_t i{0}; i < request_len; i++)
-          buffer_.push_back(buff[i]);
+          .read(buff.data(),create_enum_bool());
+        buffer_.reserve(buff.size());
+        for (const auto& v : buff) buffer_.push_back(v == Bool::TRUE);
       } else {
         this->set_.select({i_file_}, {request_len}).read(buffer_);
       }

--- a/include/fire/io/h5/Reader.h
+++ b/include/fire/io/h5/Reader.h
@@ -267,7 +267,8 @@ class Reader : public ::fire::io::Reader {
      * We have a compile-time split in order to patch 
      * [a bug](https://github.com/BlueBrain/HighFive/issues/490)
      * in HighFive that doesn't allow writing of std::vector<bool>
-     * due to the specialization of it.
+     * due to the specialization of it **and** to translate
+     * our custom enum fire::io::Bool into bools.
      *
      * After reading the next chunk into memory, we update our
      * indicies by resetting the in-memory index to 0 and moving
@@ -287,7 +288,11 @@ class Reader : public ::fire::io::Reader {
       }
       // load the next chunk into memory
       if constexpr (std::is_same_v<AtomicType,bool>) {
-        // get around std::vector<bool> specialization
+        /**
+         * compile-time split for bools which
+         * 1. gets around the std::vector<bool> specialization
+         * 2. allows us to translate io::Bool into bools
+         */
         std::vector<Bool> buff;
         buff.resize(request_len);
         this->set_.select({i_file_}, {request_len})

--- a/src/fire/io/Atomic.cxx
+++ b/src/fire/io/Atomic.cxx
@@ -1,0 +1,14 @@
+#include "fire/h5/Atomic.h"
+
+namespace fire::h5 {
+
+HighFive::EnumType<Bool> create_enum_bool() {
+  return {{"TRUE" , Bool::TRUE },
+          {"FALSE", Bool::FALSE}};
+}
+
+}  // namespace fire::h5
+
+/// register our enum type with HighFive
+HIGHFIVE_REGISTER_TYPE(fire::h5::Bool, fire::h5::create_enum_bool)
+

--- a/src/fire/io/Atomic.cxx
+++ b/src/fire/io/Atomic.cxx
@@ -1,14 +1,16 @@
-#include "fire/h5/Atomic.h"
+#include "fire/io/Atomic.h"
 
-namespace fire::h5 {
+namespace fire::io {
 
 HighFive::EnumType<Bool> create_enum_bool() {
   return {{"TRUE" , Bool::TRUE },
           {"FALSE", Bool::FALSE}};
 }
 
-}  // namespace fire::h5
+}  // namespace fire::io
 
-/// register our enum type with HighFive
-HIGHFIVE_REGISTER_TYPE(fire::h5::Bool, fire::h5::create_enum_bool)
+template<>
+HighFive::DataType HighFive::create_datatype<fire::io::Bool>() {
+  return fire::io::create_enum_bool();
+}
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,3 +17,7 @@ target_link_libraries(test_fire PRIVATE Boost::unit_test_framework framework)
 add_test(NAME "TestFire"
   COMMAND $<TARGET_FILE:test_fire> --report_level=detailed
 )
+
+add_test(NAME "h5pyReadBools"
+  COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/read-bools.py ${CMAKE_CURRENT_BINARY_DIR}/production_mode_output.h5
+)

--- a/test/read-bools.py
+++ b/test/read-bools.py
@@ -1,0 +1,5 @@
+import h5py
+import numpy as np
+import sys
+with h5py.File(sys.argv[1]) as f :
+    assert f['events/EventHeader/isRealData'].dtype == np.dtype('bool')


### PR DESCRIPTION
I have updated the specializations with an `HighFive::EnumType` which mimics the serialization done by `h5py`. This allows the bools serialized by `fire` to be interpreted as `dtype('bool')` when de-serialized with `h5py`.

## To Do
- [x] Documentation update
- [x] Add test to make sure bools written out can be read as correct dtype in h5py

**This is a breaking change. Any files serialized with prior versions that have a `bool` in them will not be read in properly with this update.**