### PR TITLE
add in non-existent output file special error

### DIFF
--- a/include/fire/io/Writer.h
+++ b/include/fire/io/Writer.h
@@ -102,7 +102,7 @@ class Writer {
       buffers_.emplace(
           path, std::make_unique<Buffer<AtomicType>>(
                     rows_per_chunk_,
-                    file_.createDataSet(path, space_,t,create_props_)));
+                    file_->createDataSet(path, space_,t,create_props_)));
     }
     dynamic_cast<Buffer<AtomicType>&>(*buffers_.at(path)).save(val);
   }
@@ -207,6 +207,7 @@ class Writer {
       buffer_.push_back(val);
       if (buffer_.size() > this->max_len_) flush();
     }
+
     /**
      * Flush our in-memory buffer onto disk
      *
@@ -259,8 +260,14 @@ class Writer {
   };
 
  private:
-  /// our highfive file
-  HighFive::File file_;
+  /**
+   * our highfive file
+   *
+   * we need it to be a smart pointer because we want to
+   * do some parameter validation before creating the file in
+   * the constructor
+   */
+  std::unique_ptr<HighFive::File> file_;
   /// the creation properties to be used on datasets we are writing
   HighFive::DataSetCreateProps create_props_;
   /// the dataspace shared amongst all of our datasets

--- a/python/fire/cfg/_process.py
+++ b/python/fire/cfg/_process.py
@@ -1,5 +1,7 @@
 """Configuration of fire Process"""
 
+from ._output_file import OutputFile
+
 class Process:
     """Process configuration object
 
@@ -67,7 +69,7 @@ class Process:
         self.max_tries = 1
         self.run = -1
         self.input_files = []
-        self.output_file = None
+        self.output_file = OutputFile('')
         self.sequence = []
         self.drop_keep_rules = []
 
@@ -150,7 +152,6 @@ class Process:
             # leave early because we already modified 'dict' in above member functions
             return
 
-        from ._output_file import OutputFile
         if name == 'output_file' and not isinstance(value,OutputFile) :
             value = OutputFile(value)
 

--- a/src/fire/io/Writer.cxx
+++ b/src/fire/io/Writer.cxx
@@ -5,11 +5,18 @@
 namespace fire::io {
 
 Writer::Writer(const int& event_limit, const config::Parameters& ps)
-    : file_(ps.get<std::string>("name"),
-            HighFive::File::Create | HighFive::File::Truncate),
-      create_props_{},
+    : create_props_{},
       space_(std::vector<std::size_t>({0}), 
           std::vector<std::size_t>({HighFive::DataSpace::UNLIMITED})) {
+  auto filename{ps.get<std::string>("name")};
+  if (filename.empty()) {
+    throw fire::Exception("NoOutputFile",
+        "No output file was provided to fire\n"
+        "         Use `p.output_file = 'my-file.h5'` in your python config.",
+        false);
+  }
+  file_ = std::make_unique<HighFive::File>(filename,
+        HighFive::File::Create | HighFive::File::Truncate);
   // down here with = to allow implicit cast from 'int' to 'std::size_t'
   entries_ = event_limit;
   rows_per_chunk_ = ps.get<int>("rows_per_chunk");
@@ -25,18 +32,18 @@ void Writer::flush() {
   for (auto& [path, buff] : buffers_) {
     buff->flush();
   }
-  file_.flush();
+  file_->flush();
 }
 
-const std::string& Writer::name() const { return file_.getName(); }
+const std::string& Writer::name() const { return file_->getName(); }
 
 void Writer::setTypeName(const std::string& full_obj_name, const std::string& type) { 
   std::string full_path = constants::EVENT_GROUP+"/"+full_obj_name;
   // if full_path goes to a dataset
-  if (file_.getObjectType(full_path) == HighFive::ObjectType::Dataset) {
-    file_.getDataSet(full_path).createAttribute(constants::TYPE_ATTR_NAME, type);
+  if (file_->getObjectType(full_path) == HighFive::ObjectType::Dataset) {
+    file_->getDataSet(full_path).createAttribute(constants::TYPE_ATTR_NAME, type);
   } else {
-    file_.getGroup(full_path).createAttribute(constants::TYPE_ATTR_NAME, type);
+    file_->getGroup(full_path).createAttribute(constants::TYPE_ATTR_NAME, type);
   }
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(test_fire
   storage_control.cxx
   conditions.cxx
   highlevel.cxx
+  helper_exceptions.cxx
   )
   
 target_link_libraries(test_fire PRIVATE Boost::unit_test_framework framework) 

--- a/test/helper_exceptions.cxx
+++ b/test/helper_exceptions.cxx
@@ -1,0 +1,65 @@
+#include <boost/test/tools/interface.hpp>
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+#include "fire/Process.h"
+#include "fire/config/Parameters.h"
+
+namespace fire::test {
+
+bool is_no_output_file_exception(const fire::Exception& e) {
+  bool pass{e.category() == "NoOutputFile"};
+  if (not pass) {
+    std::cerr << e.category() << std::endl;
+  }
+  return pass;
+}
+
+}
+
+/**
+ * Make sure helpful, high-level exceptions are being thrown
+ *
+ * - no output file -> specific NoFile exception
+ */
+BOOST_AUTO_TEST_SUITE(helper_exceptions)
+
+BOOST_AUTO_TEST_CASE(no_output_file) {
+  fire::config::Parameters configuration;
+  configuration.add("pass_name",std::string("test"));
+
+  fire::config::Parameters output_file;
+  output_file.add<std::string>("name", "");
+  output_file.add("event_limit", 10);
+  output_file.add("rows_per_chunk", 1000);
+  output_file.add("compression_level", 6);
+  output_file.add("shuffle",false);
+  configuration.add("output_file",output_file);
+  
+  fire::config::Parameters storage;
+  storage.add("default_keep",true);
+  configuration.add("storage",storage);
+
+  configuration.add("event_limit", 10);
+  configuration.add("log_frequency", -1);
+
+  configuration.add("run", 1);
+  configuration.add("max_tries", 1);
+
+  fire::config::Parameters test_add;
+  test_add.add<std::string>("name","test_add");
+  test_add.add<std::string>("class_name","fire::test::TestAdd");
+
+  fire::config::Parameters test_get;
+  test_get.add<std::string>("name","test_get");
+  test_get.add<std::string>("class_name","fire::test::TestGet");
+  test_get.add("same_sequence", true);
+
+  configuration.add<std::vector<fire::config::Parameters>>("sequence", {test_add, test_get});
+  configuration.add<fire::config::Parameters>("conditions",{});
+
+  BOOST_CHECK_EXCEPTION(std::make_unique<fire::Process>(configuration), 
+      fire::Exception, fire::test::is_no_output_file_exception);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
this required a few more changes that I hoped but it is worth it

- convert Writer::file_ to a unique ptr so that we can do parameter
  checking before construction
- throw a special category of exception when no output file is provided
- add a test for making sure that this occurs when the output file
  provided is the empty string
- update the python config so that the default output file is the empty
  string so the exception occurs when the user does not provide an
  output file
