### PR TITLE
implement a copy method for h5 readers

### DIFF
--- a/include/fire/Event.h
+++ b/include/fire/Event.h
@@ -406,7 +406,12 @@ class Event {
       //    loading may throw an H5 error if the shape of the data on disk
       //    cannot be loaded into the input type
       try {
-        for (std::size_t i{0}; i < i_entry_+1; i++) input_file_->load_into(*obj.data_);
+        if (not obj.should_save_) {
+          // only skip the first i_entry_ entries if this object is not being saved
+          //  the objects that are being saved are being mirrored by the input file
+          for (std::size_t i{0}; i < i_entry_; i++) input_file_->load_into(*obj.data_);
+        }
+        input_file_->load_into(*obj.data_);
       } catch (const HighFive::DataSetException&) {
         throw Exception("BadType",
             "Data " + full_name + " could not be loaded into "

--- a/include/fire/Event.h
+++ b/include/fire/Event.h
@@ -47,7 +47,8 @@ class Event {
      * @param keep if we should write this object into the output file
      */
     EventObjectTag(const std::string& name, const std::string& pass,
-                   const std::string& type, bool keep);
+                   const std::string& type, bool keep)
+      : name_{name}, pass_{pass}, type_{type}, keep_{keep} {}
 
     /**
      * Pass the three pieces of information to our class via an array.
@@ -58,43 +59,38 @@ class Event {
      * @param[in] obj array of name, pass, typename (that order)
      * @param keep if we should write this object into the output file
      */
-    EventObjectTag(std::array<std::string,3> obj, bool keep);
+    EventObjectTag(std::array<std::string,3> obj, bool keep)
+      : EventObjectTag(obj[0],obj[1],obj[2],keep) {}
   
     /**
      * Get the object name
      * @return name of event object
      */
-    const std::string& name() const;
+    const std::string& name() const { return name_; }
   
     /**
      * Get the pass name the object was produced on
      * @return pass name
      */
-    const std::string& pass() const;
+    const std::string& pass() const { return pass_; }
   
     /**
      * Get the name of the type of the object
      * @return demangled type name
      */
-    const std::string& type() const;
+    const std::string& type() const { return type_; }
 
     /**
      * Get if this object will be kept (i.e. written to the output file)
      * @return true if object will be written
      */
-    const bool keep() const;
+    const bool keep() const { return keep_; }
 
     /**
      * Get if this object is currently loaded in memory
      * @return true if there is a memory representation of this object
      */
-    const bool loaded() const;
-
-    /**
-     * Get the full name relative to the events group in the file
-     * @return full name of this event object in a file
-     */
-    const std::string fullName() const;
+    const bool loaded() const { return loaded_; }
   
     /**
      * String method for printing this tag in a helpful manner
@@ -385,8 +381,8 @@ class Event {
       // 1. get whether the object should be copied to the output file and
       // 2. set the loaded_ flag to true
       auto tag_it = std::find_if(available_objects_.begin(), available_objects_.end(), 
-          [&full_name](const EventObjectTag& tag) {
-            return tag.fullName() == full_name;
+          [&full_name,this](const EventObjectTag& tag) {
+            return fullName(tag.name(),tag.pass()) == full_name;
           });
       tag_it->loaded_ = true;
 

--- a/include/fire/Event.h
+++ b/include/fire/Event.h
@@ -380,6 +380,7 @@ class Event {
       // when setting up the in-memory object, we need to find the tag so we can
       // 1. get whether the object should be copied to the output file and
       // 2. set the loaded_ flag to true
+      // we can do a simple linear search since this will only happen once per input file
       auto tag_it = std::find_if(available_objects_.begin(), available_objects_.end(), 
           [&full_name,this](const EventObjectTag& tag) {
             return fullName(tag.name(),tag.pass()) == full_name;
@@ -562,10 +563,6 @@ class Event {
   struct EventObject {
     /**
      * the data for save/load
-     *
-     * this pointer will be nullptr for the data objects
-     * that have been seen in an input file but not requested
-     * by a Processor through Event::get
      */
     std::unique_ptr<io::BaseData> data_;
     /// should we save the data into output file?

--- a/include/fire/Event.h
+++ b/include/fire/Event.h
@@ -407,9 +407,11 @@ class Event {
       //    loading may throw an H5 error if the shape of the data on disk
       //    cannot be loaded into the input type
       try {
-        if (not obj.should_save_) {
-          // only skip the first i_entry_ entries if this object is not being saved
+        if (not obj.should_save_ or not input_file_->canCopy()) {
+          // only skip the first i_entry_ entries if the input file cannot copy
+          // or the object is not being saved
           //  the objects that are being saved are being mirrored by the input file
+          //  if the input file can copy
           for (std::size_t i{0}; i < i_entry_; i++) input_file_->load_into(*obj.data_);
         }
         input_file_->load_into(*obj.data_);

--- a/include/fire/Event.h
+++ b/include/fire/Event.h
@@ -142,7 +142,7 @@ class Event {
      * into a memory object.
      *
      * We need to be mutable so that we can be changed during
-     * get which is a const member function.
+     * Event::get which is a const member function.
      */
     mutable bool loaded_{false};
   };

--- a/include/fire/io/Constants.h
+++ b/include/fire/io/Constants.h
@@ -27,7 +27,7 @@ struct constants {
   /// the name of the fire version attribute
   inline static const std::string VERS_ATTR_NAME = "version";
   /// the name of the size dataset for variable types
-  inline static const std::string SIZE_NAME = "size";
+  inline static const std::string SIZE_NAME = "__size__";
 };
 
 }

--- a/include/fire/io/Constants.h
+++ b/include/fire/io/Constants.h
@@ -26,6 +26,8 @@ struct constants {
   inline static const std::string TYPE_ATTR_NAME = "type";
   /// the name of the fire version attribute
   inline static const std::string VERS_ATTR_NAME = "version";
+  /// the name of the size dataset for variable types
+  inline static const std::string SIZE_NAME = "size";
 };
 
 }

--- a/include/fire/io/Data.h
+++ b/include/fire/io/Data.h
@@ -8,6 +8,7 @@
 
 #include "fire/io/AbstractData.h"
 #include "fire/io/Writer.h"
+#include "fire/io/Constants.h"
 #include "fire/io/h5/Reader.h"
 #ifdef fire_USE_ROOT
 #include "fire/io/root/Reader.h"
@@ -327,6 +328,13 @@ class Data : public AbstractData<DataType> {
    */
   template <typename MemberType>
   void attach(const std::string& name, MemberType& m) {
+    if (name == constants::SIZE_NAME) {
+      throw Exception("BadName",
+          "The member name '"+constants::SIZE_NAME+"' is not allowed due to "
+          "its use in the serialization of variable length types.\n"
+          "    Please give your member a more detailed name corresponding to "
+          "your class", false);
+    }
     members_.push_back(
         std::make_unique<Data<MemberType>>(this->path_ + "/" + name, &m));
   }
@@ -416,7 +424,7 @@ class Data<std::vector<ContentType>>
    */
   explicit Data(const std::string& path, std::vector<ContentType>* handle = nullptr)
       : AbstractData<std::vector<ContentType>>(path, handle),
-        size_{path + "/size"},
+        size_{path + "/" + constants::SIZE_NAME},
         data_{path + "/data"} {}
 
   /**
@@ -498,7 +506,7 @@ class Data<std::map<KeyType,ValType>>
    */
   explicit Data(const std::string& path, std::map<KeyType,ValType>* handle = nullptr)
       : AbstractData<std::map<KeyType,ValType>>(path, handle),
-        size_{path + "/size"},
+        size_{path + "/" + constants::SIZE_NAME},
         keys_{path + "/keys"},
         vals_{path + "/vals"} {}
 

--- a/include/fire/io/Reader.h
+++ b/include/fire/io/Reader.h
@@ -83,8 +83,11 @@ class Reader {
 
   /**
    * Copy the input object into the output file
+   * @param[in] i_entry the entry index that is being copied from this reader to output
+   * @param[in] path the full object path that should be copied
+   * @param[out] output the writer we should write the copy to
    */
-  virtual void copy(long unsigned int i_entry, const std::string& full_name, Writer& output) {
+  virtual void copy(long unsigned int i_entry, const std::string& path, Writer& output) {
     std::cerr << "[ WARN ] : " << full_name << " is supposed to be kept but has not been accessed"
       " with Event::get so it is not being written to the output file." << std::endl;
   }

--- a/include/fire/io/Reader.h
+++ b/include/fire/io/Reader.h
@@ -1,6 +1,8 @@
 #ifndef FIRE_IO_READER_H
 #define FIRE_IO_READER_H
 
+#include <iostream>
+
 #include "fire/factory/Factory.h"
 #include "fire/io/AbstractData.h"
 

--- a/include/fire/io/Reader.h
+++ b/include/fire/io/Reader.h
@@ -82,6 +82,16 @@ class Reader {
   virtual std::vector<std::array<std::string,3>> availableObjects() = 0;
 
   /**
+   * Event::get needs to know if the reader implements a copy that advances
+   * the entry index of the data sets being read
+   *
+   * @return true if the reader implements a copy
+   */
+  virtual bool canCopy() const {
+    return false;
+  }
+
+  /**
    * Copy the input object into the output file
    * @param[in] i_entry the entry index that is being copied from this reader to output
    * @param[in] path the full object path that should be copied

--- a/include/fire/io/Reader.h
+++ b/include/fire/io/Reader.h
@@ -88,7 +88,7 @@ class Reader {
    * @param[out] output the writer we should write the copy to
    */
   virtual void copy(long unsigned int i_entry, const std::string& path, Writer& output) {
-    std::cerr << "[ WARN ] : " << full_name << " is supposed to be kept but has not been accessed"
+    std::cerr << "[ WARN ] : " << path << " is supposed to be kept but has not been accessed"
       " with Event::get so it is not being written to the output file." << std::endl;
   }
 

--- a/include/fire/io/Reader.h
+++ b/include/fire/io/Reader.h
@@ -80,6 +80,14 @@ class Reader {
   virtual std::vector<std::array<std::string,3>> availableObjects() = 0;
 
   /**
+   * Copy the input object into the output file
+   */
+  virtual void copy(long unsigned int i_entry, const std::string& full_name, Writer& output) const {
+    std::cerr << "[ WARN ] : " << full_name << " is supposed to be kept but has not been accessed"
+      " with Event::get so it is not being written to the output file." << std::endl;
+  }
+
+  /**
    * Type of factory used to create readers
    */
   using Factory = ::fire::factory::Factory<Reader, std::unique_ptr<Reader>, const std::string&>;

--- a/include/fire/io/Reader.h
+++ b/include/fire/io/Reader.h
@@ -82,7 +82,7 @@ class Reader {
   /**
    * Copy the input object into the output file
    */
-  virtual void copy(long unsigned int i_entry, const std::string& full_name, Writer& output) const {
+  virtual void copy(long unsigned int i_entry, const std::string& full_name, Writer& output) {
     std::cerr << "[ WARN ] : " << full_name << " is supposed to be kept but has not been accessed"
       " with Event::get so it is not being written to the output file." << std::endl;
   }

--- a/include/fire/io/h5/Reader.h
+++ b/include/fire/io/h5/Reader.h
@@ -140,6 +140,12 @@ class Reader : public ::fire::io::Reader {
   inline std::size_t runs() const final override { return runs_; }
 
   /**
+   * We can copy
+   * @return true
+   */
+  virtual bool canCopy() const final override { return true; }
+
+  /**
    * Copy the input data set to the output file
    *
    * This happens when the input data set has passed all of the drop/keep

--- a/include/fire/io/h5/Reader.h
+++ b/include/fire/io/h5/Reader.h
@@ -348,6 +348,8 @@ class Reader : public ::fire::io::Reader {
     std::unique_ptr<BaseData> size_member_;
     /// list of sub-objects within this object
     std::vector<std::unique_ptr<MirrorObject>> obj_members_;
+    /// the last entry that was copied
+    unsigned long int last_entry_{0};
 
    public:
     /**
@@ -356,10 +358,9 @@ class Reader : public ::fire::io::Reader {
     MirrorObject(const std::string& full_name, Reader& reader);
 
     /**
-     * Copy the n entries starting from i_rel which is the entry
-     * **relative to the current read position**
+     * Copy the n entries starting from i_entry
      */
-    void copy(unsigned long int i_rel, unsigned long int n, Writer& output);
+    void copy(unsigned long int i_entry, unsigned long int n, Writer& output);
   };
 
  private:
@@ -375,8 +376,6 @@ class Reader : public ::fire::io::Reader {
   std::unordered_map<std::string, std::unique_ptr<BufferHandle>> buffers_;
   /// our in-memory mirror objects for data being copied to the output file without processing
   std::unordered_map<std::string, std::unique_ptr<MirrorObject>> mirror_objects_;
-  /// the last entry we copied over to the output file
-  unsigned long int last_entry_{0};
 };  // Reader
 
 }  // namespace fire::io::h5

--- a/include/fire/io/h5/Reader.h
+++ b/include/fire/io/h5/Reader.h
@@ -102,6 +102,8 @@ class Reader : public ::fire::io::Reader {
 
   /**
    * Get the H5 type of object at the input path
+   * @param[in] path in-file path to an HDF5 object
+   * @return HighFive::ObjectType defining the type that the object there is
    */
   HighFive::ObjectType getH5ObjectType(const std::string& path) const;
 

--- a/include/fire/io/h5/Reader.h
+++ b/include/fire/io/h5/Reader.h
@@ -133,6 +133,21 @@ class Reader : public ::fire::io::Reader {
   inline std::size_t runs() const final override { return runs_; }
 
   /**
+   * Copy the input data set to the output file
+   *
+   * This happens when the input data set has passed all of the drop/keep
+   * rules so it is supposed to be copied into the output file; however,
+   * noone has accessed it with Event::get yet so an in-memory class object
+   * has not been created for it yet.
+   *
+   * @param[in] i_entry entry we are currently on
+   * @param[in] full_name full event object name
+   * @param[in] output handle to the writer writing the output file
+   */
+  virtual void copy(unsigned long int i_entry, const std::string& full_name, 
+      Writer& output) const final override;
+
+  /**
    * Try to load a single value of an atomic type into the input handle
    *
    * If the input path does not exist in our list of buffers,

--- a/include/fire/io/h5/Reader.h
+++ b/include/fire/io/h5/Reader.h
@@ -96,9 +96,9 @@ class Reader : public ::fire::io::Reader {
    * for more flexibility in the parameter maps.
    *
    * @param[in] dataset full in-file path to H5 dataset
-   * @return HighFive::DataTypeClass specifying the atomic type of the set
+   * @return HighFive::DataType specifying the atomic type of the set
    */
-  HighFive::DataTypeClass getDataSetType(const std::string& dataset) const;
+  HighFive::DataType getDataSetType(const std::string& dataset) const;
 
   /**
    * Get the H5 type of object at the input path
@@ -146,10 +146,10 @@ class Reader : public ::fire::io::Reader {
    * has not been created for it yet.
    *
    * @param[in] i_entry entry we are currently on
-   * @param[in] full_name full event object name
+   * @param[in] path full event object name
    * @param[in] output handle to the writer writing the output file
    */
-  virtual void copy(unsigned long int i_entry, const std::string& full_name, 
+  virtual void copy(unsigned long int i_entry, const std::string& path, 
       Writer& output) final override;
 
   /**
@@ -355,7 +355,7 @@ class Reader : public ::fire::io::Reader {
     /**
      * Construct this mirror object and any of its (data or object) children
      */
-    MirrorObject(const std::string& full_name, Reader& reader);
+    MirrorObject(const std::string& path, Reader& reader);
 
     /**
      * Copy the n entries starting from i_entry

--- a/src/fire/Event.cxx
+++ b/src/fire/Event.cxx
@@ -92,8 +92,7 @@ void Event::save() {
       // need to copy this event object from the input file
       // into the output file because it is supposed to be kept
       // but hasn't been loaded by the user
-      std::cout << "Should copy " << tag.fullName() << std::endl;
-      //input_file_->copy(tag.fullName(), output_file_);
+      input_file_->copy(i_entry_, tag.fullName(), output_file_);
     }
   }
 }

--- a/src/fire/Event.cxx
+++ b/src/fire/Event.cxx
@@ -73,7 +73,9 @@ void Event::save() {
       // need to copy this event object from the input file
       // into the output file because it is supposed to be kept
       // but hasn't been loaded by the user
-      input_file_->copy(i_entry_, fullName(tag.name(), tag.pass()), output_file_);
+      input_file_->copy(i_entry_, 
+          io::constants::EVENT_GROUP+"/"+fullName(tag.name(), tag.pass()), 
+          output_file_);
     }
   }
 }

--- a/src/fire/Event.cxx
+++ b/src/fire/Event.cxx
@@ -2,25 +2,6 @@
 
 namespace fire {
 
-Event::EventObjectTag::EventObjectTag(const std::string& name, const std::string& pass,
-                 const std::string& type, bool keep)
-  : name_{name}, pass_{pass}, type_{type}, keep_{keep} {}
-
-Event::EventObjectTag::EventObjectTag(std::array<std::string,3> obj, bool keep)
-  : EventObjectTag(obj[0],obj[1],obj[2],keep) {}
-
-const std::string& Event::EventObjectTag::name() const { return name_; }
-const std::string& Event::EventObjectTag::pass() const { return pass_; }
-const std::string& Event::EventObjectTag::type() const { return type_; }
-const bool Event::EventObjectTag::keep() const { return keep_; }
-const bool Event::EventObjectTag::loaded() const { return loaded_; }
-
-const std::string Event::EventObjectTag::fullName() const {
-  /// WARN manually made the same as Event::fullName
-  //  but without the check on empty pass name
-  return pass()+"/"+name();
-}
-
 std::vector<Event::EventObjectTag> Event::search(const std::string& namematch,
                                       const std::string& passmatch,
                                       const std::string& typematch) const {
@@ -92,7 +73,7 @@ void Event::save() {
       // need to copy this event object from the input file
       // into the output file because it is supposed to be kept
       // but hasn't been loaded by the user
-      input_file_->copy(i_entry_, tag.fullName(), output_file_);
+      input_file_->copy(i_entry_, fullName(tag.name(), tag.pass()), output_file_);
     }
   }
 }

--- a/src/fire/Process.cxx
+++ b/src/fire/Process.cxx
@@ -179,14 +179,15 @@ void Process::run() {
         n_events_processed++;
       }  // loop through events
 
-      if (event_limit_ > 0 && n_events_processed == event_limit_) {
-        fire_log(info) << "Reached event limit of " << event_limit_
-                       << " events";
-      }
-
       fire_log(info) << "Closing " << input_file->name();
 
       for (auto& proc : sequence_) proc->onFileClose(input_file->name());
+
+      if (event_limit_ > 0 && n_events_processed == event_limit_) {
+        fire_log(info) << "Reached event limit of " << event_limit_
+                       << " events";
+        break;
+      }
     }  // loop through input files
 
     // copy the input run headers to the output file

--- a/src/fire/io/ParameterStorage.cxx
+++ b/src/fire/io/ParameterStorage.cxx
@@ -25,7 +25,7 @@ void Data<ParameterStorage>::load(h5::Reader& r) {
     // first load - discovery - look through file to find parameters on disk
     for (auto pname : r.list(this->path_)) {
       std::string path{this->path_+"/"+pname};
-      auto type{r.getDataSetType(path)};
+      auto type{r.getDataSetType(path).getClass()};
       if (type == HighFive::DataTypeClass::Integer) {
         int i{};
         this->handle_->parameters_[pname] = i;

--- a/src/fire/io/h5/Reader.cxx
+++ b/src/fire/io/h5/Reader.cxx
@@ -106,7 +106,9 @@ Reader::MirrorObject::MirrorObject(const std::string& path, Reader& reader)
     } else if (type == HighFive::create_datatype<fire::io::Bool>()) {
       data_ = std::make_unique<io::Data<bool>>(path);
     } else {
-      std::cerr << "BAD: Unable to deduce C++ type from H5 type." << std::endl;
+      throw Exception("UnknownDS","Unable to deduce C++ type from H5 type during a copy\n"
+        "    User could avoid this issue simply by accessing the event object within some processor during the first event.", 
+        false);
     }
   } else {
     // event object is a H5 group meaning it is more complicated

--- a/src/fire/io/h5/Reader.cxx
+++ b/src/fire/io/h5/Reader.cxx
@@ -67,19 +67,6 @@ std::vector<std::array<std::string,3>> Reader::availableObjects() {
 }
 
 void Reader::copy(unsigned int long i_entry, const std::string& path, Writer& output) {
-  /**
-   * STRATEGY:
-   *
-   * ## Initialization
-   * 1. Recurse into the 'full_name' event object obtaining a full list of all DataSets
-   * 2. While doing this, categorize the DataSets such that we can deduce if there are
-   *    "commanders" (i.e. DataSets named `size`) who will control the number of entries
-   *    read from other DataSets.
-   * 3. Set-up these atomic data sets in a structure that mimics the on-disk structure in-memory.
-   *
-   * ## Every Copy
-   * Connect the Reader::load handles immediately to the Writer::save call.
-   */
 
   // this is where recursing into the subgroups of full_name occurs
   // if this mirror object hasn't been created yet
@@ -90,28 +77,6 @@ void Reader::copy(unsigned int long i_entry, const std::string& path, Writer& ou
   // do the copying
   mirror_objects_[path]->copy(i_entry, 1, output);
 }
-
-class create_data {
-  const std::string& path_;
-  HighFive::DataType type_;
-  std::unique_ptr<BaseData> data_;
-
- public:
-  create_data(const std::string& p, HighFive::DataType t)
-    : type_{t}, path_{p} {}
-
-  std::unique_ptr<BaseData> get() {
-    return std::move(data_);
-  }
-
-  template<typename T>
-  void operator()(T) {
-    if (type_ == HighFive::create_datatype<T>()) {
-      if (data_) { char a; std::cerr << "BAD"; std::cin >> a; }
-      else data_ = std::make_unique<io::Data<T>>(path_);
-    } 
-  }
-};
 
 Reader::MirrorObject::MirrorObject(const std::string& path, Reader& reader) 
   : reader_{reader} {

--- a/src/fire/io/h5/Reader.cxx
+++ b/src/fire/io/h5/Reader.cxx
@@ -116,7 +116,7 @@ Reader::MirrorObject::MirrorObject(const std::string& path, Reader& reader)
     auto subobjs = reader_.list(path);
     for (auto& subobj : subobjs) {
       std::string sub_path{path + "/" + subobj};
-      if (subobj == "size") {
+      if (subobj == constants::SIZE_NAME) {
         size_member_ = std::make_unique<io::Data<std::size_t>>(sub_path);
       } else {
         obj_members_.emplace_back(std::make_unique<MirrorObject>(sub_path, reader_));

--- a/src/fire/io/h5/Reader.cxx
+++ b/src/fire/io/h5/Reader.cxx
@@ -182,12 +182,12 @@ void Reader::MirrorObject::copy(unsigned long int i_entry, unsigned long int n, 
     unsigned long int new_num_to_advance{0};
     for (std::size_t i{0}; i < num_to_advance; i++) {
       size_member_->load(reader_);
-      num_to_advance += dynamic_cast<Data<std::size_t>&>(*size_member_).get();
+      new_num_to_advance += dynamic_cast<Data<std::size_t>&>(*size_member_).get();
     }
     unsigned long int new_num_to_save = 0;
     for (std::size_t i{0}; i < num_to_save; i++) {
       size_member_->load(reader_);
-      num_to_save += dynamic_cast<Data<std::size_t>&>(*size_member_).get();
+      new_num_to_save += dynamic_cast<Data<std::size_t>&>(*size_member_).get();
       size_member_->save(output);
     }
 

--- a/test/highlevel.cxx
+++ b/test/highlevel.cxx
@@ -146,9 +146,10 @@ BOOST_AUTO_TEST_CASE(prod_drop_async, *boost::unit_test::depends_on("process/pro
 }
 
 BOOST_AUTO_TEST_CASE(recon_drop_async, *boost::unit_test::depends_on("highlevel/prod_drop_async")) {
-  std::string output{"recon_drop_async.h5"};
+  std::string output{"recon_drop_async.h5"},
+              pass{"test"};
   fire::config::Parameters configuration;
-  configuration.add("pass_name",std::string("test"));
+  configuration.add("pass_name",pass);
 
   fire::config::Parameters output_file;
   output_file.add("name", output);
@@ -197,16 +198,23 @@ BOOST_AUTO_TEST_CASE(recon_drop_async, *boost::unit_test::depends_on("highlevel/
 
   // check that output has keepme and keepalong while it does not
   //  have dropme or dropalong
-  std::vector<int> correct = {1,2,3,4,5,6,7,8,9,10};
+  std::vector<int> correct = {
+    1,2,3,4,5,6,7,8,9,10
+  };
+  std::vector<int> keepme_correct = {
+    100,200,300,400,500,600,700,800,900,1000
+  };
+
   H5Easy::File f(output);
-  BOOST_TEST(f.exist(fire::io::constants::EVENT_GROUP+"/keepme"));
-  BOOST_TEST(H5Easy::load<std::vector<int>>(f, fire::io::constants::EVENT_GROUP+"/keepme") == correct);
-  BOOST_TEST(f.exist(fire::io::constants::EVENT_GROUP+"/keepalong"));
-  BOOST_TEST(H5Easy::load<std::vector<int>>(f, fire::io::constants::EVENT_GROUP+"/keepalong") == correct);
-  BOOST_TEST(f.exist(fire::io::constants::EVENT_GROUP+"/keeplateget"));
-  BOOST_TEST(H5Easy::load<std::vector<int>>(f, fire::io::constants::EVENT_GROUP+"/keeplateget") == correct);
-  BOOST_TEST((!f.exist(fire::io::constants::EVENT_GROUP+"/dropme")));
-  BOOST_TEST((!f.exist(fire::io::constants::EVENT_GROUP+"/dropalong")));
+  std::string pass_grp{fire::io::constants::EVENT_GROUP+"/"+pass};
+  BOOST_TEST(f.exist(pass_grp+"/keepme"));
+  BOOST_TEST(H5Easy::load<std::vector<int>>(f, pass_grp+"/keepme") == keepme_correct);
+  BOOST_TEST(f.exist(pass_grp+"/keepalong"));
+  BOOST_TEST(H5Easy::load<std::vector<int>>(f, pass_grp+"/keepalong") == correct);
+  BOOST_TEST(f.exist(pass_grp+"/keeplateget"));
+  BOOST_TEST(H5Easy::load<std::vector<int>>(f, pass_grp+"/keeplateget") == correct);
+  BOOST_TEST(not f.exist(pass_grp+"/dropme"));
+  BOOST_TEST(not f.exist(pass_grp+"/dropalong"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/module/recon.py
+++ b/test/module/recon.py
@@ -4,4 +4,5 @@ import sys
 p.input_files = sys.argv[1:]
 import os
 p.output_file = fire.cfg.OutputFile(f'test/module/recon_{os.path.basename(p.input_files[0]).replace("root","h5")}')
+p.keep('.*')
 p.sequence = [ fire.cfg.Processor('make','bench::Recon',module='Bench') ]

--- a/test/module/src/Produce.cxx
+++ b/test/module/src/Produce.cxx
@@ -39,6 +39,7 @@ class Produce : public fire::Processor {
       val.setMomentum(rand_float(rng),rand_float(rng),rand_float(rng));
     }
     event.add("randdata", rand_data);
+    event.add("dragalong", rand_float(rng));
   }
 };  // Produce
 


### PR DESCRIPTION
This resolves #30 

## What do
- Implement a callback for `io::Reader` which is called on each on-disk object that should be saved and has not been accessed in `Event::save`
- Move drop/keep decision for read-in objects to `Event::setInputFile` so that we can determine it separate from `Event::get`
- Add keep and loaded flags to `Event::EventObjectTag` for easier passing throughout Event
- Add a `break` into the loop over input files so there aren't unnecessary opens if less events are requested
- implement the `io::h5::Reader::copy` callback
- add a copy test in-between the write and read tests within test/data.cxx to make sure copying is functional
- update the keep/drop/async tests in test/highlevel.cxx to check that the keep/drop is working for objects that aren't being accessed

## To Do
- [x] Look at implementing the `io::root::Reader::copy` method, maybe its is feasible
- [x] Code cleanup and documentation
  - Emphasize how implementing `copy` in this way relies on the important nature of the `size` data set. Make sure to point out that user classes should not save a member to the name `size`.
- [x] add a copy-along into benchmark testing