### PR TITLE
ldmx-sw Interop

### DIFF
--- a/.github/workflows/plot.py
+++ b/.github/workflows/plot.py
@@ -16,7 +16,8 @@ def bench_plot(events, trunk_time, trunk_size, dev_time, dev_size, branch_name, 
         N events values benchmarked at for both trunk and dev data
     """
 
-    fig, ((raw_time,raw_size),(ratio_time,ratio_size)) = plt.subplots(ncols=2,nrows=2, sharex='col')
+    fig, ((raw_time,raw_size),(ratio_time,ratio_size)) = plt.subplots(ncols=2,nrows=2, sharex='col',
+            gridspec_kw=dict(height_ratios = [3,1]))
     fig.set_size_inches(11,7)
     plt.suptitle(f'Comparison Between {branch_name} and trunk : {run_mode} Mode')
     plt.subplots_adjust(wspace=0.3, hspace=0.)
@@ -30,7 +31,6 @@ def bench_plot(events, trunk_time, trunk_size, dev_time, dev_size, branch_name, 
     ratio_time.set_xscale('log')
     ratio_time.set_xlabel('N Events')
     ratio_time.set_ylabel(f'{branch_name} Time / trunk Time')
-    ratio_time.set_ylim(bottom=0.,top=1.1)
     ratio_time.plot(events, dev_time/trunk_time, color = 'black')
 
     raw_size.set_ylabel('Output File Size [MB]')
@@ -41,7 +41,6 @@ def bench_plot(events, trunk_time, trunk_size, dev_time, dev_size, branch_name, 
     ratio_size.set_xscale('log')
     ratio_size.set_xlabel('N Events')
     ratio_size.set_ylabel(f'{branch_name} Size / trunk Size')
-    ratio_size.set_ylim(bottom=0.5,top=5.5)
     ratio_size.plot(events, dev_size/trunk_size, color='black')
 
 def main() :

--- a/app/fire.cxx
+++ b/app/fire.cxx
@@ -5,9 +5,6 @@
 
 #include <iostream>
 #include "fire/config/Python.h"
-/// define the object to pull parameters from
-std::string fire::config::root_object = "fire.cfg.Process.lastProcess";
-
 #include "fire/Process.h"
 
 /**
@@ -64,7 +61,8 @@ int main(int argc, char* argv[]) {
   std::unique_ptr<fire::Process> p;
   try {
     fire::config::Parameters config{
-        fire::config::run(argv[ptrpy], argv + ptrpy + 1, argc - ptrpy - 1)};
+        fire::config::run("fire.cfg.Process.lastProcess", 
+            argv[ptrpy], argv + ptrpy + 1, argc - ptrpy - 1)};
     p = std::make_unique<fire::Process>(config);
   } catch (const fire::Exception& e) {
     std::cerr << "[" << e.category() << "] " << e.message() << std::endl;

--- a/include/Framework/ConditionsObject.h
+++ b/include/Framework/ConditionsObject.h
@@ -1,0 +1,11 @@
+#ifndef FRAMEWORK_CONDITIONSOBJECT_H
+#define FRAMEWORK_CONDITIONSOBJECT_H
+
+#include "fire/ConditionsObject.h"
+
+namespace framework {
+using ConditionsObject = fire::ConditionsObject;
+}
+
+#endif
+

--- a/include/Framework/ConditionsObjectProvider.h
+++ b/include/Framework/ConditionsObjectProvider.h
@@ -1,0 +1,10 @@
+#ifndef FRAMEWORK_CONDITIONSOBJECTPROVIDER_H
+#define FRAMEWORK_CONDITIONSOBJECTPROVIDER_H
+
+#include "fire/ConditionsProvider.h"
+
+namespace framework {
+using ConditionsObjectProvider = fire::ConditionsProvider;
+}
+
+#endif

--- a/include/Framework/Configure/Parameters.h
+++ b/include/Framework/Configure/Parameters.h
@@ -1,0 +1,28 @@
+#ifndef FRAMEWORK_CONFIGURE_PARAMETERS_H
+#define FRAMEWORK_CONFIGURE_PARAMETERS_H
+
+#include "fire/config/Parameters.h"
+
+namespace framework::config {
+class Parameters {
+  fire::config::Parameters p_;
+ public:
+  Parameters(const fire::config::Parameters& p) : p_{p} {}
+  template <typename T>
+  void addParameter(const std::string& name, const T& val) {
+    p_.add(name, val);
+  }
+
+  template <typename T>
+  T getParameter(const std::string& name) const {
+    return p_.get<T>(name);
+  }
+
+  template <typename T>
+  T getParameter(const std::string& name, const T& def) const {
+    return p_.get<T>(name, def);
+  }
+};
+}
+
+#endif

--- a/include/Framework/Configure/Parameters.h
+++ b/include/Framework/Configure/Parameters.h
@@ -4,25 +4,7 @@
 #include "fire/config/Parameters.h"
 
 namespace framework::config {
-class Parameters {
-  fire::config::Parameters p_;
- public:
-  Parameters(const fire::config::Parameters& p) : p_{p} {}
-  template <typename T>
-  void addParameter(const std::string& name, const T& val) {
-    p_.add(name, val);
-  }
-
-  template <typename T>
-  T getParameter(const std::string& name) const {
-    return p_.get<T>(name);
-  }
-
-  template <typename T>
-  T getParameter(const std::string& name, const T& def) const {
-    return p_.get<T>(name, def);
-  }
-};
+using Parameters = fire::config::Parameters;
 }
 
 #endif

--- a/include/Framework/EventProcessor.h
+++ b/include/Framework/EventProcessor.h
@@ -8,6 +8,7 @@
 
 #include "fire/Processor.h"
 #include "Framework/Configure/Parameters.h"
+#include "Framework/Logger.h"
 
 /**
  * Namespace for interop with 
@@ -38,6 +39,14 @@ class Event {
    * wrap the current event with a legacy interface
    */
   Event(fire::Event& e) : event_{e} {}
+
+  /**
+   * Get the event header
+   * @return event header
+   */
+  fire::EventHeader& getEventHeader() {
+    return event_.header();
+  }
 
   /**
    * Get the event number
@@ -145,7 +154,7 @@ class EventProcessor : public fire::Processor {
    *
    * @param[in] ps Parameter set to configure the processor with
    */
-  virtual void configure(const config::Parameters& ps) {}
+  virtual void configure(config::Parameters& ps) {}
 };
 
 /**

--- a/include/Framework/EventProcessor.h
+++ b/include/Framework/EventProcessor.h
@@ -7,6 +7,7 @@
 #define FIRE_FRAMEWORK_EVENTPROCESSOR_H
 
 #include "fire/Processor.h"
+#include "Framework/Configure/Parameters.h"
 
 /**
  * Namespace for interop with 
@@ -18,17 +19,6 @@
  * using the newer style of processors.
  */
 namespace framework {
-
-/**
- * config namespace alias within framework
- */
-namespace config {
-
-/**
- * alias for Parameters within this namespace
- */
-using Parameters = fire::config::Parameters;
-}
 
 /**
  * Wrapper Event in this namespace reintroducing legacy functionality

--- a/include/Framework/Exception/Exception.h
+++ b/include/Framework/Exception/Exception.h
@@ -1,0 +1,12 @@
+#ifndef FRAMEWORK_EXCEPTION_H
+#define FRAMEWORK_EXCEPTION_H
+
+#include "fire/exception/Exception.h"
+
+namespace framework::exception {
+using Exception = fire::Exception;
+}
+
+#define EXCEPTION_RAISE(CATEGORY, MSG) throw fire::Exception(CATEGORY, MSG);
+
+#endif

--- a/include/Framework/Logger.h
+++ b/include/Framework/Logger.h
@@ -5,11 +5,6 @@
 
 namespace framework::logging {
 using logger = fire::logging::logger;
-
-logger makeLogger(const std::string& name) {
-  return fire::logging::makeLogger(name);
-}
-
 }
 
 #define ldmx_log(lvl) fire_log(lvl)

--- a/include/Framework/Logger.h
+++ b/include/Framework/Logger.h
@@ -1,0 +1,17 @@
+#ifndef FRAMEWORK_LOGGER_H
+#define FRAMEWORK_LOGGER_H
+
+#include "fire/logging/Logger.h"
+
+namespace framework::logging {
+using logger = fire::logging::logger;
+
+logger makeLogger(const std::string& name) {
+  return fire::logging::makeLogger(name);
+}
+
+}
+
+#define ldmx_log(lvl) fire_log(lvl)
+
+#endif

--- a/include/fire/Processor.h
+++ b/include/fire/Processor.h
@@ -170,6 +170,32 @@ class Processor {
    * @param[in] p pointer to current Process
    */
   virtual void attach(Process *p) final { process_ = p; }
+
+  /**
+   * Access a conditions object for the current event
+   *
+   * @see Conditions::get and Conditions::getConditionPtr for
+   * how conditions objects are retrieved.
+   *
+   * ## Usage
+   * Inside of the process function, this function can be used 
+   * following the example below.
+   * ```cpp
+   * // inside void process(Event& event) for your Processor
+   * const auto& co = getCondition<MyObjectType>("ConditionName");
+   * ```
+   * The `const` and `&` are there because `auto` is not usually
+   * able to deduce that they are necessary and without them, a
+   * deep copy of the condition object would be made at this point.
+   *
+   * @tparam T type of condition object
+   * @param[in] condition_name Name of condition object to retrieve
+   * @return const handle to the condition object
+   */
+  template <class T>
+  const T &getCondition(const std::string &condition_name) {
+    return getConditions().get<T>(condition_name);
+  }
  public:
   /**
    * The special factory used to create processors
@@ -326,31 +352,6 @@ class Processor {
   void setStorageHint(StorageControl::Hint hint,
                       const std::string &purpose = "") const;
 
-  /**
-   * Access a conditions object for the current event
-   *
-   * @see Conditions::get and Conditions::getConditionPtr for
-   * how conditions objects are retrieved.
-   *
-   * ## Usage
-   * Inside of the process function, this function can be used 
-   * following the example below.
-   * ```cpp
-   * // inside void process(Event& event) for your Processor
-   * const auto& co = getCondition<MyObjectType>("ConditionName");
-   * ```
-   * The `const` and `&` are there because `auto` is not usually
-   * able to deduce that they are necessary and without them, a
-   * deep copy of the condition object would be made at this point.
-   *
-   * @tparam T type of condition object
-   * @param[in] condition_name Name of condition object to retrieve
-   * @return const handle to the condition object
-   */
-  template <class T>
-  const T &getCondition(const std::string &condition_name) {
-    return getConditions().get<T>(condition_name);
-  }
 
   /**
    * Abort the event immediately.

--- a/include/fire/Processor.h
+++ b/include/fire/Processor.h
@@ -302,7 +302,7 @@ class Processor {
       } else {
         // old type
         ptr = std::make_unique<DerivedType>(parameters.get<std::string>("name"), process);
-        dynamic_cast<DerivedType*>(ptr.get())->configure(parameters);
+        dynamic_cast<DerivedType*>(ptr.get())->configure(const_cast<config::Parameters&>(parameters));
       }
       return ptr;
     }

--- a/include/fire/config/Parameters.h
+++ b/include/fire/config/Parameters.h
@@ -47,6 +47,11 @@ class Parameters {
     parameters_[name] = value;
   }
 
+  template <typename T>
+  void addParameter(const std::string& name, const T& value) {
+    add<T>(name,value);
+  }
+
   /**
    * Check to see if a parameter exists
    *
@@ -85,6 +90,11 @@ class Parameters {
     }
   }
 
+  template <typename T>
+  const T& getParameter(const std::string& name) const {
+    return get<T>(name);
+  }
+
   /**
    * Retrieve a parameter with a default specified.
    *
@@ -101,6 +111,11 @@ class Parameters {
 
     // get here knowing that name exists in parameters_
     return get<T>(name);
+  }
+
+  template <typename T>
+  const T& getParameter(const std::string& name, const T& def) const {
+    return get<T>(name,def);
   }
 
   /**

--- a/include/fire/config/Python.h
+++ b/include/fire/config/Python.h
@@ -17,15 +17,6 @@
 namespace fire::config {
 
 /**
- * namespace variable defining where to look for "root"
- * object to kickoff the parameter extraction from python.
- *
- * @note This variable must be defined in any executable that wishes
- * to use fire::config::run.
- */
-extern std::string root_object;
-
-/**
  * run the python script and extract the parameters
  *
  * This method contains all the parsing and execution of the python script.
@@ -42,11 +33,12 @@ extern std::string root_object;
  * can get up to a whole lot of shenanigans that can help them
  * make their work more efficient.
  *
+ * @param[in] full pythonic path to the object to kickoff extraction
  * @param[in] pythonScript Filename location of the python script.
  * @param[in] args Commandline arguments to be passed to the python script.
  * @param[in] nargs Number of commandline arguments, assumed to be >= 0
  */
-Parameters run(const std::string& pythonScript, char* args[], int nargs);
+Parameters run(const std::string& root_object, const std::string& pythonScript, char* args[], int nargs);
 
 }  // namespace fire::config
 

--- a/include/fire/io/Atomic.h
+++ b/include/fire/io/Atomic.h
@@ -3,6 +3,15 @@
 #ifndef FIRE_IO_ATOMIC_H
 #define FIRE_IO_ATOMIC_H
 
+/**
+ * Geant4 does a GLOBAL definition of the keyword TRUE
+ */
+#ifdef TRUE
+#define NEED_TO_REDEFINE_TRUE
+#undef TRUE
+#undef FALSE
+#endif
+
 #include <type_traits>
 
 #include <highfive/H5DataType.hpp>

--- a/src/fire/config/Python.cxx
+++ b/src/fire/config/Python.cxx
@@ -172,7 +172,7 @@ static Parameters getMembers(PyObject* object) {
   return std::move(params);
 }
 
-Parameters run(const std::string& pythonScript, char* args[], int nargs) {
+Parameters run(const std::string& root_object, const std::string& pythonScript, char* args[], int nargs) {
   // assumes that nargs >= 0
   //  this is true always because we error out if no python script has been
   //  found

--- a/test/config.cxx
+++ b/test/config.cxx
@@ -43,9 +43,6 @@ test_root.integer = int(sys.argv[1]) \n\
 /// the config file we will run and load
 const std::string config_file_name{"/tmp/fire_config_python_test.py"};
 
-/// change the root config object to dummy class defined in test script
-std::string fire::config::root_object = "test_root";
-
 /**
  * Test for reading configuration from python
  *
@@ -62,7 +59,7 @@ BOOST_AUTO_TEST_CASE(no_arg) {
     config_py << class_defs << '\n' << root_obj << std::endl;
   }
   char *args[1];
-  fire::config::Parameters config{fire::config::run(config_file_name, args,0)};
+  fire::config::Parameters config{fire::config::run("test_root", config_file_name, args,0)};
   BOOST_TEST(config.get<std::string>("string") == "test");
   BOOST_TEST(config.get<int>("integer") == 10);
   BOOST_TEST(config.get<double>("double") == 6.9);
@@ -109,7 +106,7 @@ BOOST_AUTO_TEST_CASE(one_arg) {
   char arg[16];
   snprintf(arg,sizeof(arg),"%d",correct);
   args[0] = arg;
-  fire::config::Parameters config{fire::config::run(config_file_name, args, 1)};
+  fire::config::Parameters config{fire::config::run("test_root", config_file_name, args, 1)};
   BOOST_TEST(config.get<int>("integer") == correct);
 }
 
@@ -119,7 +116,7 @@ BOOST_AUTO_TEST_CASE(no_root) {
     config_py << class_defs << std::endl;
   }
   char *args[1];
-  BOOST_CHECK_THROW(fire::config::run(config_file_name,args,0), fire::Exception);
+  BOOST_CHECK_THROW(fire::config::run("test_root", config_file_name,args,0), fire::Exception);
 }
 BOOST_AUTO_TEST_CASE(py_except) {
   {
@@ -127,7 +124,7 @@ BOOST_AUTO_TEST_CASE(py_except) {
     config_py << class_defs << "\n" << throw_exception << "\n" << root_obj << std::endl;
   }
   char *args[1];
-  BOOST_CHECK_THROW(fire::config::run(config_file_name,args,0), fire::Exception);
+  BOOST_CHECK_THROW(fire::config::run("test_root", config_file_name,args,0), fire::Exception);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/legacy_processor.cxx
+++ b/test/legacy_processor.cxx
@@ -11,7 +11,7 @@ class TestProducer : public framework::Producer {
  public:
   TestProducer(const std::string& n, framework::Process& p)
     : framework::Producer(n,p) {}
-  void configure(const framework::config::Parameters& ps) final override {
+  void configure(framework::config::Parameters& ps) final override {
     run_header_ = ps.getParameter<int>("run");
   }
   void produce(framework::Event& event) final override {

--- a/test/legacy_processor.cxx
+++ b/test/legacy_processor.cxx
@@ -11,8 +11,8 @@ class TestProducer : public framework::Producer {
  public:
   TestProducer(const std::string& n, framework::Process& p)
     : framework::Producer(n,p) {}
-  void configure(const fire::config::Parameters& ps) final override {
-    run_header_ = ps.get<int>("run");
+  void configure(const framework::config::Parameters& ps) final override {
+    run_header_ = ps.getParameter<int>("run");
   }
   void produce(framework::Event& event) final override {
     auto ievent{event.getEventNumber()};


### PR DESCRIPTION
Various header introductions and patches to make inter-op with ldmx-sw procede more smoothly.

- 3532c5e19b13501a62036f25539a0beeb0311aa3 and 0719dc2e713c20a4c327b80bac639a09bdd77d3a provide more headers that are used within ldmx-sw
- 14f4658d9aaf7e1dd844bad2a3ce343a83244cd9 moves the pythonic object path defining the root of the parameter extraction to be an argument to the function
- 46a5c878e9722783beb8c811784774dca777bc86 moves getCondition to public instead of protected for better access from classes managed by a processor
- bf54405483ee168a6dac92568592a11f46715343 moves some interop to the base classes (e.g. Parameters) to avoid rvalue/lvalue conversion errors
- 91dca91bd88e0de2718de3174a600b1af5fa3547 undefines the macros `TRUE` and `FALSE` since they are defined GLOBALLY by geant4 (worried about this one, but need to forge ahead)