### PR TITLE
hide io data

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -170,15 +170,16 @@ necessary to interface with fire's serialization method.
 ```cpp
 #include "fire/io/Data.h"
 class MyData {
-  friend class fire::io::Data<MyData>;
+  friend class fire::io::access;
   MyData() = default;
   void clear();
-  void attach(fire::io::Data<MyData>& d);
+  template<typename Data>
+  void attach(Data& d);
 };
 ```
 
 The user class has four necessary components:
-1. Your class declares the the wrapping io::Data class as a `friend`.
+1. Your class declares the accessor struct class as a `friend`.
    - This allows the io::Data class access to the (potentially private)
      methods defined below.
 2. Your class has a (public or private) default constructor.
@@ -191,7 +192,7 @@ The user class has four necessary components:
    - This is used by fire to reset the data at the end of each event.
    - Similar to the default constructor, this method can be public 
      or private.
-4. Your class implements a `void attach(fire::io::Data<MyData>& d)` method.
+4. Your class implements a `void attach(Data& d)` method.
    - This method should be private since it should not be called by
      other parts of your code.
    - More detail below.
@@ -204,7 +205,8 @@ method. This is best illustrated with an example.
 
 ```cpp
 // member_one_ and member_two_ are members of MyData
-void MyData::attach(fire::io::Data<MyData>& d) {
+template<typename Data>
+void MyData::attach(Data& d) {
   d.attach("first_member", member_one_);
   d.attach("another_member", member_two_);
 }

--- a/include/fire/EventHeader.h
+++ b/include/fire/EventHeader.h
@@ -161,7 +161,7 @@ class EventHeader {
 
  private:
   /// allow data set access for reading/writing
-  friend class fire::io::Data<EventHeader>;
+  friend class fire::io::access;
 
   /**
    * attach to the serializing h5::Data wrapper
@@ -172,7 +172,16 @@ class EventHeader {
    *
    * @param[in] d h5::Data to attach to
    */
-  void attach(fire::io::Data<EventHeader>& d);
+  template<typename DataSet>
+  void attach(DataSet& d) {
+    // make sure we use the name for this variable that the reader expects
+    d.attach(fire::io::constants::NUMBER_NAME,eventNumber_);
+    d.attach("run",run_);
+    d.attach("timestamp",time_);
+    d.attach("weight",weight_);
+    d.attach("isRealData",isRealData_);
+    d.attach("parameters",parameters_);
+  }
 
   /**
    * The event number.
@@ -206,6 +215,9 @@ class EventHeader {
   fire::io::ParameterStorage parameters_;
 
 #ifdef fire_USE_ROOT
+  /// allow direct data access for load translation
+  friend class fire::io::Data<ldmx::EventHeader>;
+
   /**
    * member used only for reading from ROOT input files
    */

--- a/include/fire/RunHeader.h
+++ b/include/fire/RunHeader.h
@@ -149,7 +149,7 @@ class RunHeader {
 
  private:
   /// friends with the h5::Data that can read/write us
-  friend class fire::io::Data<RunHeader>;
+  friend class fire::io::access;
 
   /**
    * Attach to our fire::io::Data
@@ -158,7 +158,16 @@ class RunHeader {
    *
    * @param[in] d fire::io::Data to attach to
    */
-  void attach(fire::io::Data<RunHeader>& d);
+  template<typename DataSet>
+  void attach(DataSet& d) {
+    d.attach(fire::io::constants::NUMBER_NAME,runNumber_);
+    d.attach("start",runStart_);
+    d.attach("end",runEnd_);
+    d.attach("detectorName",detectorName_);
+    d.attach("description",description_);
+    d.attach("softwareTag",softwareTag_);
+    d.attach("parameters",parameters_);
+  }
 
  private:
   /** Run number. */
@@ -186,6 +195,9 @@ class RunHeader {
   fire::io::ParameterStorage parameters_;
 
 #ifdef fire_USE_ROOT
+  /// allow direct member access for the load translation
+  friend class fire::io::Data<ldmx::RunHeader>;
+  
   /**
    * member only used for reading ROOT files
    */

--- a/include/fire/io/Access.h
+++ b/include/fire/io/Access.h
@@ -5,12 +5,35 @@
 
 namespace fire::io {
 
+/**
+ * empty struct for connecting a instance of Data
+ * and the type it wraps
+ *
+ * This struct has no members or instance methods,
+ * it is merely here to grant Data access to 
+ * the potentially private function `attach`.
+ *
+ * A class interested in being wrapped by Data
+ * should declare this struct as its friend.
+ * ```cpp
+ * friend class fire::io::access;
+ * ```
+ */
 struct access {
+  /**
+   * Connect the input types by attaching t
+   * to do
+   *
+   * @tparam T type of class with attach method defined
+   * @tparam D type of class to pass to attach
+   * @param[in] t handle of class to call attach on
+   * @param[in] d handle of class to pass into attach
+   */
   template <typename T, typename D>
   static void connect(T& t, D& d) {
     t.attach(d);
   }
-};
+};  // access
 
 }
 

--- a/include/fire/io/Access.h
+++ b/include/fire/io/Access.h
@@ -1,0 +1,15 @@
+#ifndef FIRE_IO_ACCESS_H
+#define FIRE_IO_ACCESS_H
+
+namespace fire::io {
+
+struct access {
+  template <typename T, typename D>
+  static void connect(T& t, D& d) {
+    t.attach(d);
+  }
+};
+
+}
+
+#endif

--- a/include/fire/io/Access.h
+++ b/include/fire/io/Access.h
@@ -1,6 +1,8 @@
 #ifndef FIRE_IO_ACCESS_H
 #define FIRE_IO_ACCESS_H
 
+#include "fire/version/Version.h"
+
 namespace fire::io {
 
 struct access {

--- a/include/fire/io/Data.h
+++ b/include/fire/io/Data.h
@@ -7,6 +7,7 @@
 #include <map>
 
 #include "fire/exception/Exception.h"
+#include "fire/io/Access.h"
 #include "fire/io/AbstractData.h"
 #include "fire/io/Writer.h"
 #include "fire/io/Constants.h"
@@ -113,7 +114,7 @@ class Data : public AbstractData<DataType> {
    */
   explicit Data(const std::string& path, Reader* input_file = nullptr, DataType* handle = nullptr)
       : AbstractData<DataType>(path, input_file, handle), input_file_{input_file} {
-    this->handle_->attach(*this);
+    fire::io::access::connect(*this->handle_, *this);
   }
 
   /**

--- a/include/fire/io/Data.h
+++ b/include/fire/io/Data.h
@@ -67,11 +67,12 @@ AbstractData<DataType>::AbstractData(const std::string& path, Reader* input_file
  *   MyData() = default; // required by serialization technique
  *   // other public members
  *  private:
- *   friend class fire::io::Data<MyData>;
- *   void attach(fire::io::Data<MyData>& set) {
- *     set.attach("my_double",my_double_);
- *     if (set.version() < 2) set.rename("old","new",new_);
- *     else set.attach("new",new_);
+ *   friend class fire::io::access;
+ *   template<typename Data>
+ *   void attach(Data& d) {
+ *     d.attach("my_double",my_double_);
+ *     if (d.version() < 2) d.rename("old","new",new_);
+ *     else d.attach("new",new_);
  *   }
  *   void clear() {
  *     my_double_ = -1; // reset to default value

--- a/src/fire/EventHeader.cxx
+++ b/src/fire/EventHeader.cxx
@@ -10,16 +10,6 @@ namespace fire {
 const std::string EventHeader::NAME = fire::io::constants::EVENT_GROUP
   +"/"+fire::io::constants::EVENT_HEADER_NAME;
 
-void EventHeader::attach(fire::io::Data<EventHeader>& d) {
-  // make sure we use the name for this variable that the reader expects
-  d.attach(fire::io::constants::NUMBER_NAME,eventNumber_);
-  d.attach("run",run_);
-  d.attach("timestamp",time_);
-  d.attach("weight",weight_);
-  d.attach("isRealData",isRealData_);
-  d.attach("parameters",parameters_);
-}
-
 }
 
 #ifdef fire_USE_ROOT
@@ -27,7 +17,7 @@ namespace fire::io {
 
 Data<ldmx::EventHeader>::Data(const std::string& path, Reader* input_file, ldmx::EventHeader* eh)
   : AbstractData<ldmx::EventHeader>(path,input_file, eh), input_file_{input_file} {
-  this->handle_->attach(*this);
+  fire::io::access::connect(*this->handle_, *this);
 }
 
 void Data<ldmx::EventHeader>::load(h5::Reader& r) {

--- a/src/fire/RunHeader.cxx
+++ b/src/fire/RunHeader.cxx
@@ -29,16 +29,6 @@ void RunHeader::stream(std::ostream &s) const {
 
 void RunHeader::Print() const { stream(std::cout); }
 
-void RunHeader::attach(fire::io::Data<RunHeader>& d) {
-  d.attach(fire::io::constants::NUMBER_NAME,runNumber_);
-  d.attach("start",runStart_);
-  d.attach("end",runEnd_);
-  d.attach("detectorName",detectorName_);
-  d.attach("description",description_);
-  d.attach("softwareTag",softwareTag_);
-  d.attach("parameters",parameters_);
-}
-
 }  // namespace fire/ldmx
 
 #ifdef fire_USE_ROOT
@@ -46,7 +36,7 @@ namespace fire::io {
 
 Data<ldmx::RunHeader>::Data(const std::string& path, Reader* input_file, ldmx::RunHeader* eh)
   : AbstractData<ldmx::RunHeader>(path,input_file, eh), input_file_{input_file} {
-  this->handle_->attach(*this);
+  fire::io::access::connect(*this->handle_, *this);
 }
 
 void Data<ldmx::RunHeader>::load(h5::Reader& r) {

--- a/test/data.cxx
+++ b/test/data.cxx
@@ -14,8 +14,9 @@ class Hit {
   double energy_;
   int id_;
  private:
-  friend class fire::io::Data<Hit>;
-  void attach(fire::io::Data<Hit>& d) {
+  friend class fire::io::access;
+  template<typename DataSet>
+  void attach(DataSet& d) {
     d.attach("energy",energy_);
     d.attach("id",id_);
   }
@@ -36,8 +37,9 @@ class SpecialHit {
   int super_id_;
   Hit hit_;
  private:
-  friend class fire::io::Data<SpecialHit>;
-  void attach(fire::io::Data<SpecialHit>& d) {
+  friend class fire::io::access;
+  template<typename DataSet>
+  void attach(DataSet& d) {
     d.attach("super_id",super_id_);
     d.attach("hit",hit_);
   }
@@ -58,8 +60,9 @@ class Cluster {
   int id_;
   std::vector<Hit> hits_;
  private:
-  friend class fire::io::Data<Cluster>;
-  void attach(fire::io::Data<Cluster>& d) {
+  friend class fire::io::access;
+  template <typename DataSet>
+  void attach(DataSet& d) {
     d.attach("id", id_);
     d.attach("hits",hits_);
   }

--- a/test/highlevel.cxx
+++ b/test/highlevel.cxx
@@ -28,11 +28,12 @@ class DummyInt {
  public:
   fire_class_version(1);
   int i;
-  friend class fire::io::Data<DummyInt>;
+  friend class fire::io::access;
   void clear() {
     i = 0.;
   }
-  void attach(fire::io::Data<DummyInt>& d) {
+  template<typename D>
+  void attach(D& d) {
     d.attach("i",i);
   }
   DummyInt(int _i) : i{_i} {}

--- a/test/module/src/Hit.cxx
+++ b/test/module/src/Hit.cxx
@@ -1,6 +1,6 @@
 #include "Hit.h"
 
-#ifdef USE_ROOT
+#ifdef fire_USE_ROOT
 ClassImp(bench::Hit);
 #endif
 
@@ -46,21 +46,6 @@ void Hit::setMomentum(const float px, const float py, const float pz) {
   this->px_ = px;
   this->py_ = py;
   this->pz_ = pz;
-}
-
-void Hit::attach(fire::io::Data<Hit>& d) {
-  d.attach("layerID", layerID_);
-  d.attach("moduleID", moduleID_);
-  d.attach("time", time_);
-  d.attach("px", px_);
-  d.attach("py", py_);
-  d.attach("pz", pz_);
-  d.attach("energy",energy_);
-  d.attach("x", x_);
-  d.attach("y", y_);
-  d.attach("z", z_);
-  d.attach("trackID",trackID_);
-  d.attach("pdgID",pdgID_);
 }
 
 }  // namespace bench

--- a/test/module/src/Hit.h
+++ b/test/module/src/Hit.h
@@ -5,9 +5,11 @@
 #include <iostream>
 
 // H5
-#include "fire/io/Data.h"
+// this header also include the version
+// header defining whether we USE_ROOT or not
+#include "fire/io/Access.h"
 
-#ifdef USE_ROOT
+#ifdef fire_USE_ROOT
 #include "TObject.h"
 #endif
 
@@ -208,10 +210,24 @@ class Hit {
    */
   int pdgID_{0};
 
-  friend class fire::io::Data<Hit>;
-  void attach(fire::io::Data<Hit>& d);
+  friend class fire::io::access;
+  template <typename DataSet>
+  void attach(DataSet& d) {
+    d.attach("layerID", layerID_);
+    d.attach("moduleID", moduleID_);
+    d.attach("time", time_);
+    d.attach("px", px_);
+    d.attach("py", py_);
+    d.attach("pz", pz_);
+    d.attach("energy",energy_);
+    d.attach("x", x_);
+    d.attach("y", y_);
+    d.attach("z", z_);
+    d.attach("trackID",trackID_);
+    d.attach("pdgID",pdgID_);
+  }
 
-#ifdef USE_ROOT
+#ifdef fire_USE_ROOT
   ClassDef(Hit,1);
 #endif
 };  // Hit

--- a/test/module/src/Hit.h
+++ b/test/module/src/Hit.h
@@ -3,6 +3,7 @@
 
 // STL
 #include <iostream>
+#include <vector>
 
 // H5
 // this header also include the version

--- a/test/schema_evolution.cxx
+++ b/test/schema_evolution.cxx
@@ -4,7 +4,7 @@
 
 #include <highfive/H5Easy.hpp>
 
-#include "fire/io/Data.h"
+#include "fire/io/Access.h"
 #include "fire/Process.h"
 #include "fire/config/Parameters.h"
 

--- a/test/schema_evolution.cxx
+++ b/test/schema_evolution.cxx
@@ -14,11 +14,12 @@ class Double {
  public:
   fire_class_version(1);
   double d_;
-  friend class fire::io::Data<Double>;
+  friend class fire::io::access;
   void clear() {
     d_ = 0.;
   }
-  void attach(fire::io::Data<Double>& d) {
+  template<typename DataSet>
+  void attach(DataSet& d) {
     d.attach("dv1",d_);
   }
   Double(double d) : d_{d} {}
@@ -31,14 +32,15 @@ class Double {
   fire_class_version(2);
   double d_;
   int i_;
-  friend class fire::io::Data<Double>;
+  friend class fire::io::access;
   void clear() {
     d_ = 0.;
   }
-  void attach(fire::io::Data<Double>& d) {
+  template<typename DataSet>
+  void attach(DataSet& d) {
     if (d.version() < 2) {
       d.rename("dv1","dv2",d_);
-      d.attach("i",i_,fire::io::Data<Double>::SaveLoad::SaveOnly);
+      d.attach("i",i_,DataSet::SaveLoad::SaveOnly);
     } else {
       d.attach("dv2", d_);
       d.attach("i",i_);
@@ -54,14 +56,15 @@ class Double {
   fire_class_version(3);
   double d_;
   int i_;
-  friend class fire::io::Data<Double>;
+  friend class fire::io::access;
   void clear() {
     d_ = 0.;
   }
-  void attach(fire::io::Data<Double>& d) {
+  template<typename DataSet>
+  void attach(DataSet& d) {
     if (d.version() < 2) {
       d.rename("dv1","dv3",d_);
-      d.attach("i",i_,fire::io::Data<Double>::SaveLoad::SaveOnly);
+      d.attach("i",i_,DataSet::SaveLoad::SaveOnly);
     } else if (d.version() == 2) {
       d.rename("dv2","dv3",d_);
       d.attach("i",i_);


### PR DESCRIPTION
This resolves #26 and updates the `fire::io` infrastructure to support "up-calling" the attach method so that derived classes can serialize their base classes.

## To Do
- [x] Update documentation to explain purpose of `access` struct and its usage
- [x] Add inheritance test